### PR TITLE
New validation rule for booking dates

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -13,6 +13,6 @@ class Booking < ApplicationRecord
   def start_must_be_before_end
     return unless start && self.end
 
-    errors.add(:start, "must be before end") if start >= self.end
+    errors.add(:start, "can't be after the end date") if start > self.end
   end
 end


### PR DESCRIPTION
Fixed - Booking start and end dates can now be the same day. Start date can never be after the end date