### PR TITLE
Change link on index page of spaces

### DIFF
--- a/app/views/spaces/index.html.erb
+++ b/app/views/spaces/index.html.erb
@@ -14,16 +14,13 @@
             <%= space.location %>
           </h6>
 
-          <h6 class="card-text">
-            <%= space.description %>
-          </h6>
           <br>
 
           <div class="d-flex justify-content-between">
             <h6 class="card-subtitle mb-2 text-muted">
               $<%= space.price %>
             </h6>
-            <%= link_to "Book this space", new_space_booking_path(space), class:"card-link" %>
+            <%= link_to "More details", space, class:"card-link" %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Small update to include a link to the show page of every space on the cards on the index page

<img width="2551" alt="Screenshot 2024-04-12 at 2 19 36 pm" src="https://github.com/tarakoomen/spotto/assets/152606014/a8dc5b3f-9de9-41b6-a3f2-4c4bd34323db">
